### PR TITLE
Default Docker Values

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM openjdk:11
 ENV API_PORT=8080
+ENV DISCOVERY_HOSTNAME="localhost:8081"
 
 COPY target/service-gateway-0.0.1-SNAPSHOT.jar /opt/lib/
 
 ENTRYPOINT ["java"]
-CMD ["-jar", "/opt/lib/service-gateway-0.0.1-SNAPSHOT.jar", "--server.port=${API_PORT}"]
+CMD ["-jar", \
+    "/opt/lib/service-gateway-0.0.1-SNAPSHOT.jar", \
+    "--server.port=${API_PORT}", \
+    "--eureka.client.service-url.defaultZone=http://${DISCOVERY_HOSTNAME}/eureka" \
+]

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,14 @@
 spring.application.name=service-gateway
+
+# Default values for Dev
+server.port=8080
 eureka.client.service-url.defaultZone=http://localhost:8081/eureka
 
 zuul.strip-prefix=false
 
 ## Authentication Path ##
-zuul.routes.authentication.path=/refresh
+zuul.routes.authentication.path=/tokens
 zuul.routes.authentication.service-id=service-authentication
+
+zuul.routes.login.path=/login
+zuul.routes.login.service-id=service-authentication


### PR DESCRIPTION
In the interest of moving to docker-compose for local development where the port and other spring values are overriden, it is useful to have a default port when docker is not in use.

Additionally the Dockerfile was improved, and the login route added.